### PR TITLE
Restyled hero image so page title can now go in widget area. To add a

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -117,8 +117,48 @@ function register_hero_widget() {
     register_widget( 'Hero_Widget' );
 }
 add_action( 'widgets_init', 'register_hero_widget' );
-
 /* End hero widget */
+
+/* Allow HTML in widget titles */
+function html_widget_title( $title ) {
+//HTML tag opening/closing brackets
+$title = str_replace( '[', '<', $title );
+$title = str_replace( '[/', '</', $title );
+// bold -- changed from 's' to 'strong' because of strikethrough code
+$title = str_replace( 'strong]', 'strong>', $title );
+$title = str_replace( 'b]', 'b>', $title );
+// italic
+$title = str_replace( 'em]', 'em>', $title );
+$title = str_replace( 'i]', 'i>', $title );
+// underline
+// $title = str_replace( 'u]', 'u>', $title ); // could use this, but it is deprecated so use the following instead
+$title = str_replace( '<u]', '<span style="text-decoration:underline;">', $title );
+$title = str_replace( '</u]', '</span>', $title );
+// superscript
+$title = str_replace( 'sup]', 'sup>', $title );
+// subscript
+$title = str_replace( 'sub]', 'sub>', $title );
+// del
+$title = str_replace( 'del]', 'del>', $title ); // del is like strike except it is not deprecated, but strike has wider browser support -- you might want to replace the following 'strike' section to replace all with 'del' instead
+// strikethrough or <s></s>
+$title = str_replace( 'strike]', 'strike>', $title );
+$title = str_replace( 's]', 'strike>', $title ); // <s></s> was deprecated earlier than so we will convert it
+$title = str_replace( 'strikethrough]', 'strike>', $title ); // just in case you forget that it is 'strike', not 'strikethrough'
+// wtitle1 (to be styled in style.css using .wtitle1 class)
+$title = str_replace( '<wtitle1]', '<span class="wtitle1">', $title );
+$title = str_replace( '</wtitle1]', '</span>', $title );
+// wtitle2 (to be styled in style.css using .wtitle2 class)
+$title = str_replace( '<wtitle2]', '<span class="wtitle2">', $title );
+$title = str_replace( '</wtitle2]', '</span>', $title );
+
+return $title;
+}
+add_filter( 'widget_title', 'html_widget_title' );
+
+/* End HTML in widget titles */
+
+
+
 
 /**
  * Register our sidebars and widgetized areas.

--- a/style.css
+++ b/style.css
@@ -448,8 +448,8 @@ body, a {
 }
 
 #primary #site_content_menu {
-    border : 1px solid yellow ;
-    margin-top : 150px ;
+    border : 0px solid yellow ;
+    margin-top : 50px ;
 }
 
 #primary #site_content_menu ul {
@@ -468,19 +468,16 @@ body, a {
 }
 /* ------- END CUSTOMIZABLE SITE MENU ---------- */
 
-/* ------ STYLE THE HERO IMAGE -------- */
-
-#hero_widget {
-    margin : 0px ;
-}
+/* ------ STYLE THE HERO WIDGET -------- */
 
 #hero_text {
     height : 50px ;
 }
 
 #hero_text h3 {
-    color : red ;
     padding : 40px ;
+    width : 100% ;
+    text-align : center ;
 }
 
 /* ------ END STYLE THE HERO IMAGE -------- */


### PR DESCRIPTION
Center for Digital Scholarship page header to every page, edit the Hero
Image widget, and add Center for Digital Scholarship as the Widget
Title (leave the image field blank, it will disappear soon). You can
use basic HTML styling in the widget (using square brackets, not pointy
brackets). You can add [wtitle1] [/wtitle1] to add a span with a class
of .wtitle1, and then add that style to the CSS, if you want.